### PR TITLE
Improve map pin contrast and defaults

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -131,8 +131,6 @@ export default function Home() {
               icon={SPORT_ICONS[a.sport] || DEFAULT_ICON}
               color={SPORT_COLORS?.[a.sport] || "#1976D2"}
               size={40} // ajuste 36–48 conforme seu gosto
-              bg="#FFFFFF"
-              border="#FFFFFF"
               onIconLoaded={() => handleMarkerIconLoaded(a.id)}
             />
           </Marker>

--- a/components/MapPin.tsx
+++ b/components/MapPin.tsx
@@ -13,20 +13,23 @@ type Props = {
 export default function MapPin({
   icon,
   color = "#1976D2",
-  bg = "#FFFFFF",
+  bg,
   size = 40,
-  border = "#FFFFFF",
+  border,
   onIconLoaded,
 }: Props) {
+  const backgroundColor = bg ?? color;
+  const borderColor = border ?? color;
+
   const circle = {
     width: size,
     height: size,
     borderRadius: size / 2,
-    backgroundColor: bg,
+    backgroundColor,
     alignItems: "center" as const,
     justifyContent: "center" as const,
     borderWidth: 2,
-    borderColor: border,
+    borderColor,
     // sombra sutil (iOS/Android)
     shadowColor: "#000",
     shadowOpacity: 0.2,
@@ -56,13 +59,19 @@ export default function MapPin({
     backgroundColor: "rgba(0,0,0,0.15)",
   };
 
+  const iconStyle = {
+    width: size * 0.6,
+    height: size * 0.6,
+    tintColor: backgroundColor === color ? "#FFFFFF" : undefined,
+  } as const;
+
   return (
     <View style={{ alignItems: "center" }}>
       {/* “gota” = círculo + ponteiro */}
-      <View style={[circle, { borderColor: color }]}>
+      <View style={circle}>
         <Image
           source={icon}
-          style={{ width: size * 0.6, height: size * 0.6 }}
+          style={iconStyle}
           resizeMode="contain"
           onLoad={() => onIconLoaded?.()}
         />


### PR DESCRIPTION
## Summary
- derive the map pin background from the accent color so sport icons stand out without requiring overrides
- tint sport icons when using the default background to preserve their visibility on darker fills
- drop the hard-coded white background/border on activity markers to pick up the new defaults

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68d1947d49d8832390b33efce281e66f