### PR TITLE
Adjust MapPin tint handling

### DIFF
--- a/components/MapPin.tsx
+++ b/components/MapPin.tsx
@@ -8,6 +8,7 @@ type Props = {
   size?: number;             // diâmetro da “bolinha” do pin
   border?: string;           // cor da borda da bolinha
   onIconLoaded?: () => void; // callback opcional quando o ícone terminar de carregar
+  monochromeIcon?: boolean;  // define se o ícone é monocromático e pode receber tintColor
 };
 
 export default function MapPin({
@@ -17,6 +18,7 @@ export default function MapPin({
   size = 40,
   border,
   onIconLoaded,
+  monochromeIcon = false,
 }: Props) {
   const backgroundColor = bg ?? color;
   const borderColor = border ?? color;
@@ -62,7 +64,8 @@ export default function MapPin({
   const iconStyle = {
     width: size * 0.6,
     height: size * 0.6,
-    tintColor: backgroundColor === color ? "#FFFFFF" : undefined,
+    tintColor:
+      monochromeIcon && backgroundColor === color ? "#FFFFFF" : undefined,
   } as const;
 
   return (


### PR DESCRIPTION
## Summary
- add a monochromeIcon flag to MapPin props
- apply a white tint only when monochrome icons are requested so colored PNGs retain their hues

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1a4e32f10832387776c243310cc91