### PR TITLE
Ensure realtime subscription respects active filters

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -86,7 +86,7 @@ export default function Home() {
     let unsub = () => {};
     (async () => {
       await fetchUpcoming(days, sportFilter);
-      unsub = subscribeRealtime();
+      unsub = subscribeRealtime({ days, sport: sportFilter });
     })();
     return () => unsub();
   }, [days, sportFilter]);

--- a/store/useActivities.ts
+++ b/store/useActivities.ts
@@ -11,12 +11,17 @@ type NewActivity = {
   lng: number;
 };
 
+type SubscriptionFilters = {
+  days: number;
+  sport?: string;
+};
+
 type State = {
   activities: Activity[];
   loading: boolean;
   fetchUpcoming: (days: number, sport?: string) => Promise<void>;
   createActivity: (input: NewActivity) => Promise<string | undefined>;
-  subscribeRealtime: () => () => void;
+  subscribeRealtime: (filters: SubscriptionFilters) => () => void;
 };
 
 export const useActivities = create<State>((set, get) => ({
@@ -71,13 +76,15 @@ export const useActivities = create<State>((set, get) => ({
     return id;
   },
 
-  subscribeRealtime() {
+  subscribeRealtime({ days, sport }: SubscriptionFilters) {
     const ch = supabase
       .channel("activities-changes")
       .on(
         "postgres_changes",
         { event: "*", schema: "public", table: "activities" },
-        () => { get().fetchUpcoming(7); }
+        () => {
+          get().fetchUpcoming(days, sport);
+        }
       )
       .subscribe();
 


### PR DESCRIPTION
## Summary
- update the activities store realtime subscription to capture the active filters and reuse them when refetching
- pass the selected days/sport filters when subscribing on the home screen so realtime updates respect the UI filters

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1adbacbe48323962a4805da1e8bce