### PR TITLE
Manage auth subscription lifecycle

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -6,9 +6,12 @@ import { useAuth } from "../store/useAuth";
 
 export default function Layout() {
   const router = useRouter();
-  const { session, loading, hydrate, signOut } = useAuth();
+  const { session, loading, hydrate, clearAuthListener, signOut } = useAuth();
 
-  useEffect(() => { hydrate(); }, []);
+  useEffect(() => {
+    void hydrate();
+    return () => clearAuthListener();
+  }, [clearAuthListener, hydrate]);
 
   return (
     <Stack

--- a/app/auth.tsx
+++ b/app/auth.tsx
@@ -6,17 +6,20 @@ import { useAuth } from "../store/useAuth";
 
 export default function AuthScreen() {
   const router = useRouter();
-  const { session, loading, hydrate, signInWithEmail } = useAuth();
+  const { session, loading, hydrate, clearAuthListener, signInWithEmail } = useAuth();
   const [email, setEmail] = useState("");
 
-  useEffect(() => { hydrate(); }, []);
+  useEffect(() => {
+    void hydrate();
+    return () => clearAuthListener();
+  }, [clearAuthListener, hydrate]);
 
   // se já estiver logado, volta
   useEffect(() => {
     if (!loading && session) {
       router.replace("/");
     }
-  }, [loading, session]);
+  }, [loading, router, session]);
 
   async function onSend() {
     if (!email.includes("@")) {

--- a/store/useAuth.ts
+++ b/store/useAuth.ts
@@ -2,26 +2,74 @@
 import { create } from "zustand";
 import { supabase } from "../lib/supabase";
 
+type AuthSubscription = ReturnType<
+  typeof supabase.auth.onAuthStateChange
+>["data"]["subscription"];
+
+let authSubscription: AuthSubscription | null = null;
+let hydrationPromise: Promise<void> | null = null;
+let hydrationConsumers = 0;
+
 type AuthState = {
   session: import("@supabase/supabase-js").Session | null;
   loading: boolean;
   hydrate: () => Promise<void>;
+  clearAuthListener: () => void;
   signInWithEmail: (email: string) => Promise<void>;
   signOut: () => Promise<void>;
 };
 
-export const useAuth = create<AuthState>((set) => ({
+export const useAuth = create<AuthState>((set, get) => ({
   session: null,
   loading: true,
 
   async hydrate() {
-    const { data: { session } } = await supabase.auth.getSession();
-    set({ session, loading: false });
+    hydrationConsumers += 1;
 
-    // escuta mudanças de sessão (login/logout)
-    supabase.auth.onAuthStateChange((_event, newSession) => {
-      set({ session: newSession, loading: false });
-    });
+    const hadSubscription = Boolean(authSubscription);
+
+    if (!authSubscription) {
+      const {
+        data: { subscription },
+      } = supabase.auth.onAuthStateChange((_event, newSession) => {
+        set({ session: newSession, loading: false });
+      });
+      authSubscription = subscription;
+    }
+
+    const shouldFetchSession = !hadSubscription || get().loading;
+
+    if (shouldFetchSession) {
+      if (!hydrationPromise) {
+        hydrationPromise = supabase.auth
+          .getSession()
+          .then(({ data: { session } }) => {
+            set({ session, loading: false });
+          })
+          .finally(() => {
+            hydrationPromise = null;
+          });
+      }
+
+      return hydrationPromise;
+    }
+
+    if (hydrationPromise) {
+      return hydrationPromise;
+    }
+
+    return Promise.resolve();
+  },
+
+  clearAuthListener() {
+    if (hydrationConsumers > 0) {
+      hydrationConsumers -= 1;
+    }
+
+    if (hydrationConsumers === 0 && authSubscription) {
+      authSubscription.unsubscribe();
+      authSubscription = null;
+    }
   },
 
   async signInWithEmail(email: string) {


### PR DESCRIPTION
## Summary
- track the Supabase auth subscription in the store and expose a cleanup helper
- make hydrate idempotent by reusing the stored subscription/promise
- update layout and auth screens to call hydrate with cleanup support

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b315f54083238b59fd08155c7afe