### PR TITLE
Add client-side clustering to activity map

### DIFF
--- a/components/MapPin.tsx
+++ b/components/MapPin.tsx
@@ -1,5 +1,5 @@
 // components/MapPin.tsx
-import { Image, View } from "react-native";
+import { Image, Text, View } from "react-native";
 
 type Props = {
   icon: any;                 // require(...) do PNG
@@ -11,6 +11,55 @@ type Props = {
   monochromeIcon?: boolean;  // define se o ícone é monocromático e pode receber tintColor
 };
 
+type PinStyleOptions = {
+  color: string;
+  bg?: string;
+  border?: string;
+  size: number;
+};
+
+const buildPinStyles = ({ color, bg, border, size }: PinStyleOptions) => {
+  const backgroundColor = bg ?? color;
+  const borderColor = border ?? color;
+
+  return {
+    circle: {
+      width: size,
+      height: size,
+      borderRadius: size / 2,
+      backgroundColor,
+      alignItems: "center" as const,
+      justifyContent: "center" as const,
+      borderWidth: 2,
+      borderColor,
+      shadowColor: "#000",
+      shadowOpacity: 0.2,
+      shadowRadius: 3,
+      shadowOffset: { width: 0, height: 1 },
+      elevation: 3,
+    },
+    pointer: {
+      width: 0,
+      height: 0,
+      borderLeftWidth: size * 0.18,
+      borderRightWidth: size * 0.18,
+      borderTopWidth: size * 0.22,
+      borderLeftColor: "transparent",
+      borderRightColor: "transparent",
+      borderTopColor: color,
+      marginTop: -1,
+    },
+    ring: {
+      position: "absolute" as const,
+      bottom: -size * 0.3,
+      width: size * 0.6,
+      height: size * 0.18,
+      borderRadius: size,
+      backgroundColor: "rgba(0,0,0,0.15)",
+    },
+  } as const;
+};
+
 export default function MapPin({
   icon,
   color = "#1976D2",
@@ -20,52 +69,13 @@ export default function MapPin({
   onIconLoaded,
   monochromeIcon = false,
 }: Props) {
-  const backgroundColor = bg ?? color;
-  const borderColor = border ?? color;
-
-  const circle = {
-    width: size,
-    height: size,
-    borderRadius: size / 2,
-    backgroundColor,
-    alignItems: "center" as const,
-    justifyContent: "center" as const,
-    borderWidth: 2,
-    borderColor,
-    // sombra sutil (iOS/Android)
-    shadowColor: "#000",
-    shadowOpacity: 0.2,
-    shadowRadius: 3,
-    shadowOffset: { width: 0, height: 1 },
-    elevation: 3,
-  };
-
-  const pointer = {
-    width: 0,
-    height: 0,
-    borderLeftWidth: size * 0.18,
-    borderRightWidth: size * 0.18,
-    borderTopWidth: size * 0.22,
-    borderLeftColor: "transparent",
-    borderRightColor: "transparent",
-    borderTopColor: color,
-    marginTop: -1,
-  };
-
-  const ring = {
-    position: "absolute" as const,
-    bottom: -size * 0.30,
-    width: size * 0.6,
-    height: size * 0.18,
-    borderRadius: size,
-    backgroundColor: "rgba(0,0,0,0.15)",
-  };
+  const fillColor = bg ?? color;
+  const { circle, pointer, ring } = buildPinStyles({ color, bg, border, size });
 
   const iconStyle = {
     width: size * 0.6,
     height: size * 0.6,
-    tintColor:
-      monochromeIcon && backgroundColor === color ? "#FFFFFF" : undefined,
+    tintColor: monochromeIcon && fillColor === color ? "#FFFFFF" : undefined,
   } as const;
 
   return (
@@ -81,6 +91,50 @@ export default function MapPin({
       </View>
       <View style={pointer} />
       {/* sombra no chão (oval) */}
+      <View style={ring} />
+    </View>
+  );
+}
+
+type ClusterPinProps = {
+  count: number;
+  color?: string;
+  size?: number;
+  textColor?: string;
+};
+
+export function MapClusterPin({
+  count,
+  color = "#1976D2",
+  size = 48,
+  textColor = "#FFFFFF",
+}: ClusterPinProps) {
+  const { circle, pointer, ring } = buildPinStyles({ color, size });
+  const displayCount = count > 999 ? "999+" : String(count);
+  const labelLength = displayCount.length;
+  const fontSize =
+    labelLength >= 4
+      ? size * 0.28
+      : labelLength === 3
+        ? size * 0.32
+        : labelLength === 2
+          ? size * 0.36
+          : size * 0.42;
+
+  return (
+    <View style={{ alignItems: "center" }}>
+      <View style={circle}>
+        <Text
+          style={{
+            color: textColor,
+            fontWeight: "700",
+            fontSize,
+          }}
+        >
+          {displayCount}
+        </Text>
+      </View>
+      <View style={pointer} />
       <View style={ring} />
     </View>
   );


### PR DESCRIPTION
## Summary
- add a client-side clustering helper so nearby activities collapse into aggregate markers and zoom when touched
- wire the new cluster-aware map into the home screen and keep existing activity marker behaviour intact
- extend MapPin with a reusable builder and introduce MapClusterPin for custom cluster counters

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b99be1488323895351c5d8f50d13