### PR TITLE
fix: keep map pin wrapper view

### DIFF
--- a/components/MapPin.tsx
+++ b/components/MapPin.tsx
@@ -75,7 +75,7 @@ export default function MapPin({
   } as const;
 
   return (
-    <View style={{ alignItems: "center" }}>
+    <View style={{ alignItems: "center" }} collapsable={false}>
       {/* “gota” = círculo + ponteiro */}
       <View style={circle}>
         <Image
@@ -118,7 +118,7 @@ export function MapClusterPin({
           : size * 0.42;
 
   return (
-    <View style={{ alignItems: "center" }}>
+    <View style={{ alignItems: "center" }} collapsable={false}>
       <View style={circle}>
         <Text
           style={{


### PR DESCRIPTION
## Summary
- prevent React Native from removing pin wrapper views by setting `collapsable={false}` on MapPin and MapClusterPin containers

## Testing
- npx expo start --android *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c92a4be48323aa1e8166eb1fe740