### PR TITLE
Use Expo Linking for auth redirect

### DIFF
--- a/store/useAuth.ts
+++ b/store/useAuth.ts
@@ -1,4 +1,5 @@
 // store/useAuth.ts
+import * as Linking from "expo-linking";
 import { create } from "zustand";
 import { supabase } from "../lib/supabase";
 
@@ -74,10 +75,11 @@ export const useAuth = create<AuthState>((set, get) => ({
 
   async signInWithEmail(email: string) {
     // envia magic link; ao clicar no e-mail no celular, volta para o app via scheme
+    const redirectTo = Linking.createURL("/auth-callback");
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: {
-        emailRedirectTo: "mvpcidade://auth-callback",
+        emailRedirectTo: redirectTo,
       },
     });
     if (error) throw new Error(error.message);


### PR DESCRIPTION
## Summary
- import Expo Linking in the auth store
- generate the redirect URL based on the current environment before sending the OTP email
- pass the generated URL to Supabase OTP sign-in so magic links return to the correct scheme

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2b5c149288323b63235df445c77bc