### PR TITLE
Ensure Supabase auth redirect uses mvpcidade scheme

### DIFF
--- a/store/useAuth.ts
+++ b/store/useAuth.ts
@@ -75,7 +75,9 @@ export const useAuth = create<AuthState>((set, get) => ({
 
   async signInWithEmail(email: string) {
     // envia magic link; ao clicar no e-mail no celular, volta para o app via scheme
-    const redirectTo = Linking.createURL("/auth-callback");
+    const redirectTo = Linking.createURL("/auth-callback", {
+      scheme: "mvpcidade",
+    });
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: {


### PR DESCRIPTION
## Summary
- force the Supabase email magic link redirect to use the mvpcidade deep-link scheme

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2b98c067c8323959a5fcb1e5a2571