### PR TITLE
Simplifica marcadores usando pins nativos

### DIFF
--- a/app/activity/[id].tsx
+++ b/app/activity/[id].tsx
@@ -1,7 +1,5 @@
 // app/activity/[id].tsx
-import MapPin from "@/components/MapPin";
 import { SPORT_COLORS } from "@/lib/colors";
-import { DEFAULT_ICON, SPORT_ICONS } from "@/lib/sportsIcons";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, Alert, Button, Platform, Pressable, ScrollView, Share, Text, View } from "react-native";
@@ -34,7 +32,6 @@ export default function ActivityDetail() {
 
   const [a, setA] = useState<Activity | null>(null);
   const [loading, setLoading] = useState(true);
-  const [iconLoaded, setIconLoaded] = useState(false);
 
   // contadores
   const [goingCount, setGoingCount] = useState(0);
@@ -47,7 +44,6 @@ export default function ActivityDetail() {
 
   const loadActivity = useCallback(async () => {
     setLoading(true);
-    setIconLoaded(false);
     const { data, error } = await supabase.from("activities").select("*").eq("id", id).single();
     if (error) Alert.alert("Erro", error.message);
     setA(data as Activity);
@@ -273,15 +269,8 @@ export default function ActivityDetail() {
             <Marker
               coordinate={{ latitude: a.lat, longitude: a.lng }}
               anchor={{ x: 0.5, y: 1 }}
-              tracksViewChanges={!iconLoaded}
-            >
-              <MapPin
-                icon={SPORT_ICONS[a.sport] || DEFAULT_ICON}
-                color={SPORT_COLORS?.[a.sport] || "#1976D2"}
-                size={36}
-                onIconLoaded={() => setIconLoaded(true)}
-              />
-            </Marker>
+              pinColor={SPORT_COLORS[a.sport] ?? "#1976D2"}
+            />
           </MapView>
         </View>
       )}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,11 +1,10 @@
 // app/index.tsx
-import { DEFAULT_ICON, SPORT_ICONS } from "@/lib/sportsIcons";
 import { Picker } from "@react-native-picker/picker";
 import * as Location from "expo-location";
 import { Link, useRouter } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ActivityIndicator, Button, Platform, Pressable, Text, View } from "react-native";
-import MapPin, { MapClusterPin } from "../components/MapPin";
+import { MapClusterPin } from "../components/MapPin";
 import { SPORT_COLORS } from "../lib/colors"; // se você tiver esse mapa; senão pode fixar uma cor
 import { SPORTS } from "../lib/sports";
 import { useActivities } from "../store/useActivities";
@@ -160,7 +159,6 @@ export default function Home() {
     null
   );
   const [locLoading, setLocLoading] = useState(true);
-  const [markerIconsLoaded, setMarkerIconsLoaded] = useState<Record<string, boolean>>({});
 
   // filtros
   const [days, setDays] = useState<1 | 7 | 30>(7);
@@ -174,15 +172,6 @@ export default function Home() {
     [activities, region]
   );
 
-  const handleMarkerIconLoaded = useCallback((activityId: string) => {
-    setMarkerIconsLoaded((prev) => {
-      if (prev[activityId]) {
-        return prev;
-      }
-      return { ...prev, [activityId]: true };
-    });
-  }, []);
-
   const handleRegionChangeComplete = useCallback((nextRegion: MapRegion) => {
     setRegion((current) => (regionsAreClose(current, nextRegion) ? current : nextRegion));
   }, []);
@@ -195,24 +184,6 @@ export default function Home() {
     },
     [region]
   );
-
-  useEffect(() => {
-    setMarkerIconsLoaded((prev) => {
-      const currentIds = new Set(activities.map((activity) => activity.id));
-      let removed = false;
-      const next: Record<string, boolean> = {};
-
-      Object.keys(prev).forEach((id) => {
-        if (currentIds.has(id)) {
-          next[id] = prev[id];
-        } else {
-          removed = true;
-        }
-      });
-
-      return removed ? next : prev;
-    });
-  }, [activities]);
 
   // pegar localização uma vez
   useEffect(() => {
@@ -301,21 +272,14 @@ export default function Home() {
               title={a.title}
               description={`${new Date(a.starts_at).toLocaleDateString()} ${new Date(a.starts_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`}
               anchor={{ x: 0.5, y: 1 }} // 👈 a “ponta” encosta no local
-              tracksViewChanges={!markerIconsLoaded[a.id]} // mantém tracking até o ícone aparecer
+              pinColor={SPORT_COLORS[a.sport] ?? "#1976D2"}
               onPress={() =>
                 router.push({
                   pathname: "/activity/[id]" as const,
                   params: { id: String(a.id) },
                 })
               }
-            >
-              <MapPin
-                icon={SPORT_ICONS[a.sport] || DEFAULT_ICON}
-                color={SPORT_COLORS?.[a.sport] || "#1976D2"}
-                size={40} // ajuste 36–48 conforme seu gosto
-                onIconLoaded={() => handleMarkerIconLoaded(a.id)}
-              />
-            </Marker>
+            />
           );
         })}
       </MapView>

--- a/components/MapPin.tsx
+++ b/components/MapPin.tsx
@@ -1,14 +1,5 @@
 // components/MapPin.tsx
-import { Image, Text, View } from "react-native";
-
-type Props = {
-  icon: any;                 // require(...) do PNG
-  color?: string;            // cor do pin (borda/ponta)
-  bg?: string;               // fundo atrás do ícone
-  size?: number;             // diâmetro da “bolinha” do pin
-  onIconLoaded?: () => void; // callback opcional quando o ícone terminar de carregar
-  monochromeIcon?: boolean;  // define se o ícone é monocromático e pode receber tintColor
-};
+import { Text, View } from "react-native";
 
 type PinStyleOptions = {
   color: string;
@@ -56,41 +47,6 @@ const buildPinStyles = ({ color, bg, size }: PinStyleOptions) => {
     },
   } as const;
 };
-
-export default function MapPin({
-  icon,
-  color = "#1976D2",
-  bg,
-  size = 40,
-  onIconLoaded,
-  monochromeIcon = false,
-}: Props) {
-  const fillColor = bg ?? "#FFFFFF";
-  const { circle, pointer, ring } = buildPinStyles({ color, bg, size });
-
-  const iconStyle = {
-    width: size * 0.6,
-    height: size * 0.6,
-    tintColor: monochromeIcon && fillColor === color ? "#FFFFFF" : undefined,
-  } as const;
-
-  return (
-    <View style={{ alignItems: "center" }} collapsable={false}>
-      {/* “gota” = círculo + ponteiro */}
-      <View style={circle}>
-        <Image
-          source={icon}
-          style={iconStyle}
-          resizeMode="contain"
-          onLoad={() => onIconLoaded?.()}
-        />
-      </View>
-      <View style={pointer} />
-      {/* sombra no chão (oval) */}
-      <View style={ring} />
-    </View>
-  );
-}
 
 type ClusterPinProps = {
   count: number;


### PR DESCRIPTION
## Summary
- troquei os marcadores das atividades na home para usar `pinColor` nativo, removendo o carregamento de ícones personalizados
- apliquei o mesmo ajuste no mini-mapa da tela de atividade para manter o comportamento consistente
- limpei `components/MapPin.tsx` para exportar apenas `MapClusterPin`, evitando código morto

## Testing
- `npm run lint` *(emite warnings já existentes sobre `require()` nos imports condicionais do MapView)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c5991ff48323ba49880483e4b68f