### PR TITLE
feat: add shared map pin component

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -12,7 +12,7 @@ import {
   Text,
   View,
 } from "react-native";
-import { MapClusterPin } from "../components/MapPin";
+import { MapClusterPin, MapPinBase } from "../components/MapPin";
 import { SPORT_COLORS } from "../lib/colors"; // se você tiver esse mapa; senão pode fixar uma cor
 import { SPORTS } from "../lib/sports";
 import { useActivities } from "../store/useActivities";
@@ -277,6 +277,8 @@ export default function Home() {
           }
 
           const a = item.activity;
+          const sportColor = SPORT_COLORS[a.sport] ?? "#1976D2";
+
           return (
             <Marker
               key={a.id}
@@ -284,14 +286,16 @@ export default function Home() {
               title={a.title}
               description={`${new Date(a.starts_at).toLocaleDateString()} ${new Date(a.starts_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`}
               anchor={{ x: 0.5, y: 1 }} // 👈 a “ponta” encosta no local
-              pinColor={SPORT_COLORS[a.sport] ?? "#1976D2"}
+              tracksViewChanges={false}
               onPress={() =>
                 router.push({
                   pathname: "/activity/[id]" as const,
                   params: { id: String(a.id) },
                 })
               }
-            />
+            >
+              <MapPinBase color={sportColor} backgroundColor={sportColor} />
+            </Marker>
           );
         })}
       </MapView>

--- a/components/MapPin.tsx
+++ b/components/MapPin.tsx
@@ -1,21 +1,28 @@
 // components/MapPin.tsx
+import type { ReactNode } from "react";
 import { Text, View } from "react-native";
 
 type PinStyleOptions = {
   color: string;
-  bg?: string;
+  backgroundColor?: string;
+  ringColor?: string;
   size: number;
 };
 
-const buildPinStyles = ({ color, bg, size }: PinStyleOptions) => {
-  const backgroundColor = bg ?? "#FFFFFF";
+const buildPinStyles = ({
+  color,
+  backgroundColor,
+  ringColor,
+  size,
+}: PinStyleOptions) => {
+  const fillColor = backgroundColor ?? color;
 
   return {
     circle: {
       width: size,
       height: size,
       borderRadius: size / 2,
-      backgroundColor,
+      backgroundColor: fillColor,
       alignItems: "center" as const,
       justifyContent: "center" as const,
       borderWidth: 2,
@@ -43,10 +50,41 @@ const buildPinStyles = ({ color, bg, size }: PinStyleOptions) => {
       width: size * 0.6,
       height: size * 0.18,
       borderRadius: size,
-      backgroundColor: "rgba(0,0,0,0.15)",
+      backgroundColor: ringColor ?? "rgba(0,0,0,0.15)",
     },
   } as const;
 };
+
+type MapPinBaseProps = {
+  color: string;
+  backgroundColor?: string;
+  ringColor?: string;
+  size?: number;
+  children?: ReactNode;
+};
+
+export function MapPinBase({
+  color,
+  backgroundColor,
+  ringColor,
+  size = 40,
+  children,
+}: MapPinBaseProps) {
+  const { circle, pointer, ring } = buildPinStyles({
+    color,
+    backgroundColor,
+    ringColor,
+    size,
+  });
+
+  return (
+    <View style={{ alignItems: "center" }} collapsable={false}>
+      <View style={circle}>{children}</View>
+      <View style={pointer} />
+      <View style={ring} />
+    </View>
+  );
+}
 
 type ClusterPinProps = {
   count: number;
@@ -61,7 +99,6 @@ export function MapClusterPin({
   size = 48,
   textColor = "#FFFFFF",
 }: ClusterPinProps) {
-  const { circle, pointer, ring } = buildPinStyles({ color, bg: color, size });
   const displayCount = count > 999 ? "999+" : String(count);
   const labelLength = displayCount.length;
   const fontSize =
@@ -74,20 +111,16 @@ export function MapClusterPin({
           : size * 0.42;
 
   return (
-    <View style={{ alignItems: "center" }} collapsable={false}>
-      <View style={circle}>
-        <Text
-          style={{
-            color: textColor,
-            fontWeight: "700",
-            fontSize,
-          }}
-        >
-          {displayCount}
-        </Text>
-      </View>
-      <View style={pointer} />
-      <View style={ring} />
-    </View>
+    <MapPinBase color={color} backgroundColor={color} size={size}>
+      <Text
+        style={{
+          color: textColor,
+          fontWeight: "700",
+          fontSize,
+        }}
+      >
+        {displayCount}
+      </Text>
+    </MapPinBase>
   );
 }


### PR DESCRIPTION
## Summary
- extract a reusable MapPinBase component that renders the pin drop shape and accepts children
- update MapClusterPin to render its counter through the shared base component
- render activity markers with MapPinBase colored by sport for consistent clustered/unclustered pins

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2d5db3e508323bfad07a74e42026d