### PR TITLE
Update activity markers to use native pin color

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -12,7 +12,7 @@ import {
   Text,
   View,
 } from "react-native";
-import { MapClusterPin, MapPinBase } from "../components/MapPin";
+import { MapClusterPin } from "../components/MapPin";
 import { SPORT_COLORS } from "../lib/colors"; // se você tiver esse mapa; senão pode fixar uma cor
 import { SPORTS } from "../lib/sports";
 import { useActivities } from "../store/useActivities";
@@ -288,15 +288,14 @@ export default function Home() {
               description={`${new Date(a.starts_at).toLocaleDateString()} ${new Date(a.starts_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`}
               anchor={{ x: 0.5, y: 1 }} // 👈 a “ponta” encosta no local
               tracksViewChanges={false}
+              pinColor={sportColor}
               onPress={() =>
                 router.push({
                   pathname: "/activity/[id]" as const,
                   params: { id: String(a.id) },
                 })
               }
-            >
-              <MapPinBase color={sportColor} backgroundColor={sportColor} />
-            </Marker>
+            />
           );
         })}
       </MapView>


### PR DESCRIPTION
## Summary
- remove the custom MapPinBase for individual activity markers
- rely on the native Marker with pinColor to preserve sport-specific colors
- clean up the MapPin import to only include the cluster pin component

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2e31217548323b2bd4de7ee9f8ed1