### PR TITLE
Adjust cluster pin coloring based on activities

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -272,7 +272,7 @@ export default function Home() {
                 description="Toque para aproximar"
                 onPress={() => handleClusterPress(item)}
               >
-                <MapClusterPin count={item.count} />
+                <MapClusterPin count={item.count} activities={item.activities} />
               </Marker>
             );
           }

--- a/components/MapPin.tsx
+++ b/components/MapPin.tsx
@@ -1,6 +1,8 @@
 // components/MapPin.tsx
 import type { ReactNode } from "react";
 import { Text, View } from "react-native";
+import { SPORT_COLORS } from "../lib/colors";
+import type { ActivityType } from "../lib/supabase";
 
 type PinStyleOptions = {
   color: string;
@@ -91,6 +93,7 @@ type ClusterPinProps = {
   color?: string;
   size?: number;
   textColor?: string;
+  activities?: ActivityType[];
 };
 
 export function MapClusterPin({
@@ -98,7 +101,16 @@ export function MapClusterPin({
   color = "#1976D2",
   size = 48,
   textColor = "#FFFFFF",
+  activities,
 }: ClusterPinProps) {
+  const uniqueSports = new Set(activities?.map((a) => a.sport));
+  const singleSport = uniqueSports.size === 1 ? Array.from(uniqueSports)[0] : undefined;
+  const computedColor =
+    uniqueSports.size > 1
+      ? "#FF3B30"
+      : singleSport
+        ? SPORT_COLORS[singleSport] ?? color
+        : color;
   const displayCount = count > 999 ? "999+" : String(count);
   const labelLength = displayCount.length;
   const fontSize =
@@ -111,7 +123,7 @@ export function MapClusterPin({
           : size * 0.42;
 
   return (
-    <MapPinBase color={color} backgroundColor={color} size={size}>
+    <MapPinBase color={computedColor} backgroundColor={computedColor} size={size}>
       <Text
         style={{
           color: textColor,


### PR DESCRIPTION
## Summary
- forward cluster activity lists to the map cluster pin component
- allow MapClusterPin to derive its color from the underlying sports, showing red for mixed clusters
- continue rendering MapPinBase with the computed color while keeping the activity count label

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2e90f33708323bb78b47d1af1096f