### PR TITLE
Fix MapPin activity type import

### DIFF
--- a/components/MapPin.tsx
+++ b/components/MapPin.tsx
@@ -2,7 +2,7 @@
 import type { ReactNode } from "react";
 import { Text, View } from "react-native";
 import { SPORT_COLORS } from "../lib/colors";
-import type { ActivityType } from "../lib/supabase";
+import type { Activity as ActivityType } from "../lib/supabase";
 
 type PinStyleOptions = {
   color: string;


### PR DESCRIPTION
## Summary
- update MapPin to import the exported Activity type from the Supabase client

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2ef24813c8323bf00b42540ba965e