### PR TITLE
Center cluster marker anchor

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -266,7 +266,7 @@ export default function Home() {
               <Marker
                 key={item.id}
                 coordinate={item.coordinate}
-                anchor={{ x: 0.5, y: 1 }}
+                anchor={{ x: 0.5, y: 0.5 }}
                 tracksViewChanges={false}
                 title={`${item.count} atividades próximas`}
                 description="Toque para aproximar"


### PR DESCRIPTION
## Summary
- center the cluster marker anchor so the circle renders from its center

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2fbd4b54c8323847a2b0b101c9844